### PR TITLE
Readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ My advice to create a simple erlang/elixir server in clojure is to create a `pro
 
 ```clojure
 (defproject calculator "0.0.1" 
-  :dependencies 
+  :dependencies [ 
 ```
-![\[](http://clojars.org/clojure-erlastic/latest-version.svg)
+  ![](http://clojars.org/clojure-erlastic/latest-version.svg)
 ```clojure
      [org.clojure/core.match "0.2.1"]])
 ```

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ My advice to create a simple erlang/elixir server in clojure is to create a `pro
 
 ```clojure
 (defproject calculator "0.0.1" 
-  :dependencies [[clojure-erlastic "0.1.4"]
+  :dependencies [[](http://clojars.org/clojure-erlastic/latest-version.svg)
                  [org.clojure/core.match "0.2.1"]])
 ```
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ My advice to create a simple erlang/elixir server in clojure is to create a `pro
 (defproject calculator "0.0.1" 
   :dependencies 
 ```
-[\[](http://clojars.org/clojure-erlastic/latest-version.svg)
+![\[](http://clojars.org/clojure-erlastic/latest-version.svg)
 ```clojure
      [org.clojure/core.match "0.2.1"]])
 ```

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ My advice to create a simple erlang/elixir server in clojure is to create a `pro
 (defproject calculator "0.0.1" 
   :dependencies 
 ```
-     [\[](http://clojars.org/clojure-erlastic/latest-version.svg)
+[\[](http://clojars.org/clojure-erlastic/latest-version.svg)
 ```clojure
      [org.clojure/core.match "0.2.1"]])
 ```

--- a/README.md
+++ b/README.md
@@ -68,8 +68,11 @@ My advice to create a simple erlang/elixir server in clojure is to create a `pro
 
 ```clojure
 (defproject calculator "0.0.1" 
-  :dependencies [[](http://clojars.org/clojure-erlastic/latest-version.svg)
-                 [org.clojure/core.match "0.2.1"]])
+  :dependencies 
+```
+     [\[](http://clojars.org/clojure-erlastic/latest-version.svg)
+```clojure
+     [org.clojure/core.match "0.2.1"]])
 ```
 
 > lein uberjar


### PR DESCRIPTION
There's a spot down in an example in the README where an old version number is hard-coded into the example. This bit me. This pull request uses the clojars link, which means it's always up to date, though it looks strange since it interrupts the code block. Alternatively you could just update the version manually, which might be a pain to remember every time you update the version number. (Or maybe just put a comment in the example to look at the version number at the top of the README.)