### PR TITLE
Fix Scalaris Maven repo URL

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,4 +10,4 @@
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/core.async "0.1.303.0-886421-alpha"]
                  [org.erlang.otp/jinterface "1.5.9"]]
-  :repositories {"scalaris" "https://scalaris.googlecode.com/svn/maven/"})
+  :repositories {"scalaris" "https://scalaris-team.github.io/scalaris/maven"})


### PR DESCRIPTION
It seems Scalaris Maven repo was moved and is not available under the old URL. Because of this `clojure-erlastic` couldn't be used unless `[org.erlang.otp/jinterface "1.5.9"]` is already present in local `.m2`.
