### PR TITLE
Remove reflection warnings and use Protocols for encoding/decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Designed to be used (but not necessarily) with
 [https://github.com/awetzel/exos](https://github.com/awetzel/exos).
 
 Last version of JInterface (from erlang 17.0) is taken from google scalaris
-maven repo. 
+maven repo.
 
 ## Usage
 
@@ -24,7 +24,8 @@ and decoded into erlang binary term following these rules :
 - erlang list is clojure list
 - erlang tuple is clojure vector
 - erlang binary is clojure bytes[]
-- erlang integer is clojure long
+- erlang integer is clojure int
+- erlang long is clojure long
 - erlang float is clojure double
 - erlang map is clojure map (thanks to erlang 17.0)
 - clojure set is erlang list
@@ -33,14 +34,14 @@ Conversion of nil and string are configurable : every functions
 `port-connection`, `decode`, `encode`, `run-server` can take an optional
 `config` argument : a map defining 3 configs `:convention`, `:str-detect`, `:str-autodetect-len`.
 
-- if `(= :convention :elixir)` then : 
+- if `(= :convention :elixir)` then :
   - clojure nil is erlang `nil` atom, so elixir `nil`
   - clojure string is encoded into erlang utf8 binary
   - erlang binaries are decoded into clojure string :
     - always if `(= :str-detect :all)`
     - never if `(= :str-detect :none)`
     - if the "str-autodetect-len" first bytes are printable when `(= :str-detect :auto)`
-- if `(= :convention :erlang)` then : 
+- if `(= :convention :erlang)` then :
   - clojure nil is erlang `undefined`
   - clojure string is encoded into erlang integer list
   - erlang lists are decoded into clojure string :
@@ -60,21 +61,21 @@ For instance, here is a simple echo server :
 
 ## Example : a simple clojure calculator ##
 
-My advice to create a simple erlang/elixir server in clojure is to create a `project.clj` containing the clojure-erlastic dependency and other needed deps for your server, then use "lein uberjar" to create a jar containing all the needed files. 
+My advice to create a simple erlang/elixir server in clojure is to create a `project.clj` containing the clojure-erlastic dependency and other needed deps for your server, then use "lein uberjar" to create a jar containing all the needed files.
 
 > mkdir calculator; cd calculator
 
 > vim project.clj
 
 ```clojure
-(defproject calculator "0.0.1" 
+(defproject calculator "0.0.1"
   :dependencies [[clojure-erlastic "0.1.4"]
                  [org.clojure/core.match "0.2.1"]])
 ```
 
 > lein uberjar
 
-Then create your clojure server as a simple script 
+Then create your clojure server as a simple script
 
 > vim calculator.clj
 
@@ -84,7 +85,7 @@ Then create your clojure server as a simple script
 (use '[clojure.core.match :only (match)])
 
 (let [[in out] (clojure-erlastic.core/port-connection)]
-  (<!! (go 
+  (<!! (go
     (loop [num 0]
       (match (<! in)
         [:add n] (recur (+ num n))
@@ -98,11 +99,11 @@ Finally launch the clojure server as a port, do not forget the `:binary` and `{:
 
 ```elixir
 defmodule CljPort do
-  def start, do: 
+  def start, do:
     Port.open({:spawn,'java -cp target/calculator-0.0.1-standalone.jar clojure.main calculator.clj'},[:binary, packet: 4])
-  def psend(port,data), do: 
+  def psend(port,data), do:
     send(port,{self,{:command,:erlang.term_to_binary(data)}})
-  def preceive(port), do: 
+  def preceive(port), do:
     receive(do: ({^port,{:data,b}}->:erlang.binary_to_term(b)))
 end
 port = CljPort.start
@@ -188,7 +189,7 @@ defmodule Myapp do
 end
 ```
 
-Then you can launch and test your application in the shell : 
+Then you can launch and test your application in the shell :
 
 ```
 iex -S mix
@@ -209,7 +210,7 @@ iex(6)> GenServer.call Calculator,:get
 
 The channels are closed when the launching erlang application dies, so you just
 have to test if `(<! in)` is `nil` to know if the connection with erlang is
-still opened.  
+still opened.
 
 ## Erlang style handler ##
 

--- a/project.clj
+++ b/project.clj
@@ -7,6 +7,7 @@
   :scm {:name "git" :url "https://github.com/awetzel/clojure-erlastic"}
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
+  :global-vars {*warn-on-reflection* true}
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/core.async "0.1.303.0-886421-alpha"]
                  [org.erlang.otp/jinterface "1.5.9"]]

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
   :global-vars {*warn-on-reflection* true}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/core.async "0.1.303.0-886421-alpha"]
-                 [org.erlang.otp/jinterface "1.5.9"]]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [org.clojure/core.async "0.3.443"]
+                 [org.erlang.otp/jinterface "1.6.1"]]
   :repositories {"scalaris" "https://scalaris-team.github.io/scalaris/maven"})

--- a/src/clojure_erlastic/core.clj
+++ b/src/clojure_erlastic/core.clj
@@ -17,7 +17,8 @@
 (defn port-connection
   ([] (port-connection default-config))
   ([config]
-   (let [in (chan) out (chan)]
+   (let [in  (chan)
+         out (chan)]
      (go ;; term receiver coroutine
        (try
          (while true

--- a/src/clojure_erlastic/core.clj
+++ b/src/clojure_erlastic/core.clj
@@ -1,129 +1,14 @@
 (ns clojure-erlastic.core
-  (:require [clojure.core.async :as async :refer [<! >! <!! chan go close!]])
-  (:import (com.ericsson.otp.erlang OtpErlangAtom OtpErlangObject OtpErlangTuple
-                                    OtpErlangString OtpErlangList OtpErlangLong
-                                    OtpErlangBinary OtpErlangDouble OtpErlangMap
-                                    OtpErlangDecodeException OtpInputStream OtpOutputStream
-                                    OtpException)
-           (java.nio.charset Charset)
-           (java.nio ByteBuffer CharBuffer)
-           (sun.nio.cs UTF_8)))
-
-;; CONFIGURATION
-(def default-config {:str-detect :none
-                     :convention :elixir
-                     :str-autodetect-len 10})
-
-(defn get-conf [config key]
-  (if (contains? config key) (config key) (default-config key)))
-
-;; String conversion and detection utility functions
-(def ^UTF_8 utf-8 "The UTF-8 charset object" (Charset/forName "UTF-8"))
-
-(def ^:private printables #{Character/UPPERCASE_LETTER Character/TITLECASE_LETTER
-                            Character/SPACE_SEPARATOR
-                            Character/PARAGRAPH_SEPARATOR Character/LOWERCASE_LETTER
-                            Character/CURRENCY_SYMBOL Character/DECIMAL_DIGIT_NUMBER
-                            Character/DASH_PUNCTUATION Character/CONNECTOR_PUNCTUATION
-                            Character/END_PUNCTUATION Character/FINAL_QUOTE_PUNCTUATION
-                            Character/INITIAL_QUOTE_PUNCTUATION Character/START_PUNCTUATION
-                            Character/OTHER_PUNCTUATION})
-
-(defn printable? [c]
-  (printables (Character/getType c)))
-
-(defn bin-str? [^bytes bin detect-len]
-  (let [char-res  (CharBuffer/allocate detect-len)
-        len       (min (alength bin) detect-len)
-        coder-res (.decode (.newDecoder utf-8) (ByteBuffer/wrap bin 0 len) char-res (= len (alength bin)))
-        char-len  (.position char-res)]
-    (doto char-res
-      (.rewind)
-      (.limit char-len))
-    (and (not (.isError coder-res))
-         (every? printable? (.toString char-res)))))
-
-(defn seq-str? [lst detect-len]
-  (every? #(and (Character/isValidCodePoint %)
-                (printable? %))
-          (take detect-len lst)))
-
-(defn str-or-bin [^bytes bin]
-  (try
-    (String. bin utf-8)
-    (catch Exception e bin)))
-
-(defn str-or-lst [lst]
-  (try (apply str (map char lst))
-       (catch Exception e lst)))
+  (:require [clojure.core.async :as async :refer [<! >! <!! chan go close!]]
+            [clojure-erlastic.decode :as d]
+            [clojure-erlastic.encode :as e]
+            [clojure-erlastic.util :refer [default-config get-conf]])
+  (:import (com.ericsson.otp.erlang OtpErlangObject OtpErlangDecodeException
+                                    OtpInputStream OtpOutputStream OtpException)))
 
 ;; Codec functions
-(defn decode
-  ([obj] (decode obj default-config))
-  ([obj config]
-   (let [t (type obj)
-         conf (fn [key] (get-conf config key))
-         dec (fn [obj] (decode obj config))]
-     (cond
-       (= t OtpErlangAtom) (let [k (keyword (.atomValue ^OtpErlangAtom obj))]
-                             (cond
-                               (#{:true :false} k) (= k :true)
-                               (and (= (conf :convention) :elixir) (= k :nil)) nil
-                               (and (= (conf :convention) :erlang) (= k :undefined)) nil
-                               :else k))
-       (= t OtpErlangList) (let [elem-seq (seq (map dec (.elements ^OtpErlangList obj)))]
-                             (cond
-                               (and (= (conf :convention) :erlang) (= (conf :str-detect) :all))
-                               (str-or-lst elem-seq)
-                               (and (= (conf :convention) :erlang) (= (conf :str-detect) :auto))
-                               (if (seq-str? elem-seq (conf :str-autodetect-len)) (str-or-lst elem-seq) elem-seq)
-                               :else elem-seq))
-       (= t OtpErlangTuple) (vec (map dec (.elements ^OtpErlangTuple obj)))
-       (= t OtpErlangString) (.stringValue ^OtpErlangString obj)
-       (= t OtpErlangBinary) (let [bin (.binaryValue ^OtpErlangBinary obj)]
-                               (cond
-                                 (and (= (conf :convention) :elixir) (= (conf :str-detect) :all))
-                                 (str-or-bin bin)
-                                 (and (= (conf :convention) :elixir) (= (conf :str-detect) :auto))
-                                 (if (bin-str? bin (conf :str-autodetect-len)) (str-or-bin bin) bin)
-                                 :else bin))
-       (= t OtpErlangMap) (zipmap (map dec (.keys ^OtpErlangMap obj))
-                                  (map dec (.values ^OtpErlangMap obj)))
-       (= t OtpErlangLong) (.longValue ^OtpErlangLong obj)
-       (= t OtpErlangDouble) (.doubleValue ^OtpErlangDouble obj)
-       :else   :decoding_error))))
-
-(defn- erlang-objects
-  #^"[Lcom.ericsson.otp.erlang.OtpErlangObject;"
-  [xs]
-  (into-array OtpErlangObject xs))
-
-(defn encode
-  ([obj] (encode obj default-config))
-  ([obj config]
-   (letfn [(conf [key] (get-conf config key))
-           (enc [obj] (encode obj config))]
-     (cond
-       (nil? obj)
-       (if (= (conf :convention) :elixir)
-         (OtpErlangAtom. "nil")
-         (OtpErlangAtom. "undefined"))
-       (char? obj) (enc (int obj))
-       (seq? obj) (OtpErlangList. (erlang-objects (map enc obj)))
-       (set? obj) (OtpErlangList. (erlang-objects (map enc obj)))
-       (vector? obj) (OtpErlangTuple. (erlang-objects (map enc obj)))
-       (string? obj)
-       (if (= (conf :convention) :elixir)
-         (OtpErlangBinary. (bytes (.getBytes ^String obj "UTF-8")))
-         (enc (seq obj)))
-       (keyword? obj) (OtpErlangAtom. (name obj))
-       (integer? obj) (OtpErlangLong. (long obj))
-       (float? obj) (OtpErlangDouble. (double obj))
-       (map? obj) (OtpErlangMap. (into-array OtpErlangObject (map enc (keys obj)))
-                                 (into-array OtpErlangObject (map enc (vals obj))))
-       (= (Class/forName "[B") (type obj)) (OtpErlangBinary. (bytes obj))
-       (= java.lang.Boolean (type obj)) (enc (keyword (str obj)))
-       :else   (enc (str obj))))))
+(def decode d/-decode-)
+(def encode e/-encode-)
 
 ;; Erlang port communication on stderr - stdin
 (defn log [& params]

--- a/src/clojure_erlastic/core.clj
+++ b/src/clojure_erlastic/core.clj
@@ -1,80 +1,102 @@
-(ns clojure-erlastic.core)
-(import '(com.ericsson.otp.erlang OtpErlangAtom OtpErlangObject OtpErlangTuple
-                                  OtpErlangString OtpErlangList OtpErlangLong
-                                  OtpErlangBinary OtpErlangDouble OtpErlangMap
-                                  OtpErlangDecodeException OtpInputStream OtpOutputStream OtpException)
-        '(java.nio.charset Charset) '(java.nio ByteBuffer CharBuffer))
-(require '[clojure.core.async :as async :refer [<! >! <!! chan go close!]])
+(ns clojure-erlastic.core
+  (:require [clojure.core.async :as async :refer [<! >! <!! chan go close!]])
+  (:import (com.ericsson.otp.erlang OtpErlangAtom OtpErlangObject OtpErlangTuple
+                                    OtpErlangString OtpErlangList OtpErlangLong
+                                    OtpErlangBinary OtpErlangDouble OtpErlangMap
+                                    OtpErlangDecodeException OtpInputStream OtpOutputStream
+                                    OtpException)
+           (java.nio.charset Charset)
+           (java.nio ByteBuffer CharBuffer)
+           (sun.nio.cs UTF_8)))
 
 ;; CONFIGURATION
-(def default-config {
-  :str-detect :none
-  :convention :elixir
-  :str-autodetect-len 10 })
-(defn get-conf [config key] 
+(def default-config {:str-detect :none
+                     :convention :elixir
+                     :str-autodetect-len 10})
+
+(defn get-conf [config key]
   (if (contains? config key) (config key) (default-config key)))
 
 ;; String conversion and detection utility functions
-(def utf-8 "The UTF-8 charset object" (Charset/forName "UTF-8"))
-(defn printable? [c]
-  (#{Character/UPPERCASE_LETTER Character/TITLECASE_LETTER Character/SPACE_SEPARATOR Character/PARAGRAPH_SEPARATOR Character/LOWERCASE_LETTER 
-     Character/CURRENCY_SYMBOL Character/DECIMAL_DIGIT_NUMBER
-     Character/DASH_PUNCTUATION Character/CONNECTOR_PUNCTUATION Character/END_PUNCTUATION Character/FINAL_QUOTE_PUNCTUATION Character/INITIAL_QUOTE_PUNCTUATION Character/START_PUNCTUATION Character/OTHER_PUNCTUATION} 
-      (Character/getType c)))
+(def ^UTF_8 utf-8 "The UTF-8 charset object" (Charset/forName "UTF-8"))
 
-(defn bin-str? [bin detect-len]
-  (let [char-res (CharBuffer/allocate detect-len)
-        len (min (alength bin) detect-len)
+(def ^:private printables #{Character/UPPERCASE_LETTER Character/TITLECASE_LETTER
+                            Character/SPACE_SEPARATOR
+                            Character/PARAGRAPH_SEPARATOR Character/LOWERCASE_LETTER
+                            Character/CURRENCY_SYMBOL Character/DECIMAL_DIGIT_NUMBER
+                            Character/DASH_PUNCTUATION Character/CONNECTOR_PUNCTUATION
+                            Character/END_PUNCTUATION Character/FINAL_QUOTE_PUNCTUATION
+                            Character/INITIAL_QUOTE_PUNCTUATION Character/START_PUNCTUATION
+                            Character/OTHER_PUNCTUATION})
+
+(defn printable? [c]
+  (printables (Character/getType c)))
+
+(defn bin-str? [^bytes bin detect-len]
+  (let [char-res  (CharBuffer/allocate detect-len)
+        len       (min (alength bin) detect-len)
         coder-res (.decode (.newDecoder utf-8) (ByteBuffer/wrap bin 0 len) char-res (= len (alength bin)))
-        char-len (.position char-res)]
-    (doto char-res (.rewind) (.limit char-len))
-    (and (not (.isError coder-res)) (every? printable? (.toString char-res)))))
+        char-len  (.position char-res)]
+    (doto char-res
+      (.rewind)
+      (.limit char-len))
+    (and (not (.isError coder-res))
+         (every? printable? (.toString char-res)))))
 
 (defn seq-str? [lst detect-len]
-  (every? #(and (Character/isValidCodePoint %) (printable? %)) (take detect-len lst)))
+  (every? #(and (Character/isValidCodePoint %)
+                (printable? %))
+          (take detect-len lst)))
 
-(defn str-or-bin [bin]
-  (try (String. bin utf-8)
-       (catch Exception e bin)))
+(defn str-or-bin [^bytes bin]
+  (try
+    (String. bin utf-8)
+    (catch Exception e bin)))
 
 (defn str-or-lst [lst]
-  (try (apply str (map char lst)) 
+  (try (apply str (map char lst))
        (catch Exception e lst)))
-        
+
 ;; Codec functions
-(defn decode 
+(defn decode
   ([obj] (decode obj default-config))
   ([obj config]
-    (let [t (type obj)
-          conf (fn [key] (get-conf config key))
-          dec (fn [obj] (decode obj config))]
-      (cond 
-        (= t OtpErlangAtom) (let [k (keyword (.atomValue obj))]
-          (cond
-            (#{:true :false} k) (= k :true) 
-            (and (= (conf :convention) :elixir) (= k :nil)) nil
-            (and (= (conf :convention) :erlang) (= k :undefined)) nil
-            :else k))
-        (= t OtpErlangList) (let [elem-seq (seq (map dec (.elements obj)))]
-          (cond 
-            (and (= (conf :convention) :erlang) (= (conf :str-detect) :all))
-              (str-or-lst elem-seq)
-            (and (= (conf :convention) :erlang) (= (conf :str-detect) :auto))
-              (if (seq-str? elem-seq (conf :str-autodetect-len)) (str-or-lst elem-seq) elem-seq)
-            :else elem-seq))
-        (= t OtpErlangTuple) (vec (map dec (.elements obj)))
-        (= t OtpErlangString) (.stringValue obj)
-        (= t OtpErlangBinary) (let [bin (.binaryValue obj)]
-          (cond 
-            (and (= (conf :convention) :elixir) (= (conf :str-detect) :all)) 
-              (str-or-bin bin)
-            (and (= (conf :convention) :elixir) (= (conf :str-detect) :auto))
-              (if (bin-str? bin (conf :str-autodetect-len)) (str-or-bin bin) bin)
-            :else bin))
-        (= t OtpErlangMap) (zipmap (map dec (.keys obj)) (map dec (.values obj)))
-        (= t OtpErlangLong) (.longValue obj)
-        (= t OtpErlangDouble) (.doubleValue obj)
-        :else   :decoding_error))))
+   (let [t (type obj)
+         conf (fn [key] (get-conf config key))
+         dec (fn [obj] (decode obj config))]
+     (cond
+       (= t OtpErlangAtom) (let [k (keyword (.atomValue ^OtpErlangAtom obj))]
+                             (cond
+                               (#{:true :false} k) (= k :true)
+                               (and (= (conf :convention) :elixir) (= k :nil)) nil
+                               (and (= (conf :convention) :erlang) (= k :undefined)) nil
+                               :else k))
+       (= t OtpErlangList) (let [elem-seq (seq (map dec (.elements ^OtpErlangList obj)))]
+                             (cond
+                               (and (= (conf :convention) :erlang) (= (conf :str-detect) :all))
+                               (str-or-lst elem-seq)
+                               (and (= (conf :convention) :erlang) (= (conf :str-detect) :auto))
+                               (if (seq-str? elem-seq (conf :str-autodetect-len)) (str-or-lst elem-seq) elem-seq)
+                               :else elem-seq))
+       (= t OtpErlangTuple) (vec (map dec (.elements ^OtpErlangTuple obj)))
+       (= t OtpErlangString) (.stringValue ^OtpErlangString obj)
+       (= t OtpErlangBinary) (let [bin (.binaryValue ^OtpErlangBinary obj)]
+                               (cond
+                                 (and (= (conf :convention) :elixir) (= (conf :str-detect) :all))
+                                 (str-or-bin bin)
+                                 (and (= (conf :convention) :elixir) (= (conf :str-detect) :auto))
+                                 (if (bin-str? bin (conf :str-autodetect-len)) (str-or-bin bin) bin)
+                                 :else bin))
+       (= t OtpErlangMap) (zipmap (map dec (.keys ^OtpErlangMap obj))
+                                  (map dec (.values ^OtpErlangMap obj)))
+       (= t OtpErlangLong) (.longValue ^OtpErlangLong obj)
+       (= t OtpErlangDouble) (.doubleValue ^OtpErlangDouble obj)
+       :else   :decoding_error))))
+
+(defn- erlang-objects
+  #^"[Lcom.ericsson.otp.erlang.OtpErlangObject;"
+  [xs]
+  (into-array OtpErlangObject xs))
 
 (defn encode
   ([obj] (encode obj default-config))
@@ -83,21 +105,21 @@
            (enc [obj] (encode obj config))]
      (cond
        (nil? obj)
-         (if (= (conf :convention) :elixir)
-             (OtpErlangAtom. "nil")
-             (OtpErlangAtom. "undefined"))
+       (if (= (conf :convention) :elixir)
+         (OtpErlangAtom. "nil")
+         (OtpErlangAtom. "undefined"))
        (char? obj) (enc (int obj))
-       (seq? obj) (OtpErlangList. (into-array OtpErlangObject (map enc obj)))
-       (set? obj) (OtpErlangList. (into-array OtpErlangObject (map enc obj)))
-       (vector? obj) (OtpErlangTuple. (into-array OtpErlangObject (map enc obj)))
-       (string? obj) 
-         (if (= (conf :convention) :elixir) 
-             (OtpErlangBinary. (bytes (.getBytes obj "UTF-8")))
-             (enc (seq obj)))
+       (seq? obj) (OtpErlangList. (erlang-objects (map enc obj)))
+       (set? obj) (OtpErlangList. (erlang-objects (map enc obj)))
+       (vector? obj) (OtpErlangTuple. (erlang-objects (map enc obj)))
+       (string? obj)
+       (if (= (conf :convention) :elixir)
+         (OtpErlangBinary. (bytes (.getBytes ^String obj "UTF-8")))
+         (enc (seq obj)))
        (keyword? obj) (OtpErlangAtom. (name obj))
        (integer? obj) (OtpErlangLong. (long obj))
        (float? obj) (OtpErlangDouble. (double obj))
-       (map? obj) (OtpErlangMap. (into-array OtpErlangObject (map enc (keys obj))) 
+       (map? obj) (OtpErlangMap. (into-array OtpErlangObject (map enc (keys obj)))
                                  (into-array OtpErlangObject (map enc (vals obj))))
        (= (Class/forName "[B") (type obj)) (OtpErlangBinary. (bytes obj))
        (= java.lang.Boolean (type obj)) (enc (keyword (str obj)))
@@ -107,47 +129,57 @@
 (defn log [& params]
   (.println System/err (apply str params)))
 
-(defn port-connection 
+(defn port-connection
   ([] (port-connection default-config))
   ([config]
-    (let [in (chan) out (chan)]
-      (go ;; term receiver coroutine
-        (try 
-          (while true 
-            (let [len-buf (byte-array 4)]
-              (.read System/in len-buf)
-              (let [term-len (.read4BE (new OtpInputStream len-buf))
-                    term-buf (byte-array term-len)]
-                (.read System/in term-buf)
-                (let [b (decode (.read_any (new OtpInputStream term-buf)) config) ]
-                  (>! in b)))))
-          (catch Exception e (do 
-            (log "receive error : " (type e) " " (.getMessage e)) 
-            (close! out) (close! in)))))
-      (go ;; term sender coroutine
-        (loop []
-          (when-let [term (<! out)]
-            (try
-              (let [out-term (new OtpOutputStream (encode term config))]
-                (doto (new OtpOutputStream) (.write4BE (+ 1 (.size out-term))) (.write 131) (.writeTo System/out))
-                (.writeTo out-term System/out)
-                (.flush System/out))
-              (catch Exception e (log "send error : " (type e) " " (.getMessage e))))
-            (recur))))
-      [in out] )))
+   (let [in (chan) out (chan)]
+     (go ;; term receiver coroutine
+       (try
+         (while true
+           (let [len-buf (byte-array 4)]
+             (.read System/in len-buf)
+             (let [term-len (.read4BE (OtpInputStream. len-buf))
+                   term-buf (byte-array term-len)]
+               (.read System/in term-buf)
+               (let [b (decode (.read_any (OtpInputStream. term-buf)) config)]
+                 (>! in b)))))
+         (catch Exception e
+           (do
+             (log "receive error : " (type e) " " (.getMessage ^Exception e))
+             (close! out)
+             (close! in)))))
+     (go ;; term sender coroutine
+       (loop []
+         (when-let [term (<! out)]
+           (try
+             (let [out-term (OtpOutputStream. ^OtpErlangObject (encode term config))]
+               (doto (OtpOutputStream.)
+                 (.write4BE (+ 1 (.size out-term)))
+                 (.write 131)
+                 (.writeTo System/out))
+               (.writeTo out-term System/out)
+               (.flush System/out))
+             (catch Exception e (log "send error : " (type e) " " (.getMessage e))))
+           (recur))))
+     [in out])))
 
 ;; erlang style genserver management
-(defn run-server 
+(defn run-server
   ([handle] (run-server (fn [state] state) handle default-config))
   ([init handle] (run-server init handle default-config))
   ([init handle config]
-    (let [[in out] (port-connection config)]
-      (<!! (go
-        (loop [state (init (<! in))]
-          (if-let [req (<! in)]
-            (let [res (try (handle req state) (catch Exception e [:stop [:error e]]))]
-              (case (res 0)
-                :reply (do (>! out (res 1)) (recur (res 2)))
-                :noreply (recur (res 1))
-                :stop (res 1)))
-            :normal)))))))
+   (let [[in out] (port-connection config)]
+     (<!! (go
+            (loop [state (init (<! in))]
+              (if-let [req (<! in)]
+                (let [res (try
+                            (handle req state)
+                            (catch Exception e
+                              [:stop [:error e]]))]
+                  (case (res 0)
+                    :reply (do
+                             (>! out (res 1))
+                             (recur (res 2)))
+                    :noreply (recur (res 1))
+                    :stop (res 1)))
+                :normal)))))))

--- a/src/clojure_erlastic/decode.clj
+++ b/src/clojure_erlastic/decode.clj
@@ -2,7 +2,8 @@
   (:require [clojure-erlastic.util :refer [get-conf printables utf-8]])
   (:import (com.ericsson.otp.erlang OtpErlangAtom OtpErlangObject OtpErlangTuple
                                     OtpErlangString OtpErlangList OtpErlangLong
-                                    OtpErlangBinary OtpErlangDouble OtpErlangMap)
+                                    OtpErlangBinary OtpErlangDouble OtpErlangMap
+                                    OtpErlangInt)
            (java.nio ByteBuffer CharBuffer)))
 
 (defn str-or-bin [^bytes bin]
@@ -118,6 +119,11 @@
   IErlang
   (-decode- [obj config]
     (.longValue obj)))
+
+(extend-type OtpErlangInt
+  IErlang
+  (-decode- [obj config]
+    (.intValue obj)))
 
 (extend-type OtpErlangDouble
   IErlang

--- a/src/clojure_erlastic/decode.clj
+++ b/src/clojure_erlastic/decode.clj
@@ -1,0 +1,130 @@
+(ns clojure-erlastic.decode
+  (:require [clojure-erlastic.util :refer [get-conf printables utf-8]])
+  (:import (com.ericsson.otp.erlang OtpErlangAtom OtpErlangObject OtpErlangTuple
+                                    OtpErlangString OtpErlangList OtpErlangLong
+                                    OtpErlangBinary OtpErlangDouble OtpErlangMap)
+           (java.nio ByteBuffer CharBuffer)))
+
+(defn str-or-bin [^bytes bin]
+  (try
+    (String. bin utf-8)
+    (catch Exception _
+      bin)))
+
+(defn str-or-lst [xs]
+  (try
+    (apply str (map char xs))
+    (catch Exception _
+      xs)))
+
+(defn- printable-long? [^Long c]
+  (contains? printables (Character/getType c)))
+
+(defn seq-str? [xs detect-len]
+  (every? #(and (Character/isValidCodePoint %)
+                (printable-long? %))
+          (take detect-len xs)))
+
+(defn- printable? [^Character c]
+  (contains? printables (Character/getType c)))
+
+(defn bin-str? [^bytes bin detect-len]
+  (let [char-res  (CharBuffer/allocate detect-len)
+        len       (min (alength bin) detect-len)
+        coder-res (.decode (.newDecoder utf-8) (ByteBuffer/wrap bin 0 len) char-res (= len (alength bin)))
+        char-len  (.position char-res)]
+    (doto char-res
+      (.rewind)
+      (.limit char-len))
+    (and (not (.isError coder-res))
+         (every? printable? (.toString char-res)))))
+
+(defprotocol IErlang
+  (-decode- [this config]))
+
+(extend-type OtpErlangAtom
+  IErlang
+  (-decode- [obj config]
+    (let [k           (keyword (.atomValue obj))
+          convention  (get-conf config :convention)]
+      (cond
+        (#{:true :false} k)
+        (= k :true)
+
+        (and (= convention :elixir)
+             (= k :nil))
+        nil
+
+        (and (= convention :erlang)
+             (= k :undefined))
+        nil
+
+        :else k))))
+
+(extend-type OtpErlangList
+  IErlang
+  (-decode- [obj config]
+    (let [elem-seq    (seq (map #(-decode- % config) (.elements obj)))
+          erlang?     (= (get-conf config :convention) :erlang)
+          str-detect  (get-conf config :str-detect)]
+      (cond
+        (and erlang? (= str-detect :all))
+        (str-or-lst elem-seq)
+
+        (and erlang? (= str-detect :auto))
+        (if (seq-str? elem-seq (get-conf config :str-autodetect-len))
+          (str-or-lst elem-seq)
+          elem-seq)
+
+        :else elem-seq))))
+
+(extend-type OtpErlangTuple
+  IErlang
+  (-decode- [obj config]
+    (mapv #(-decode- % config)
+          (.elements obj))))
+
+(extend-type OtpErlangString
+  IErlang
+  (-decode- [obj config]
+    (.stringValue obj)))
+
+(extend-type OtpErlangBinary
+  IErlang
+  (-decode- [obj config]
+    (let [bin        (.binaryValue obj)
+          elixir?    (= (get-conf config :convention) :elixir)
+          str-detect (get-conf config :str-detect)]
+      (cond
+        (and elixir? (= str-detect :all))
+        (str-or-bin bin)
+
+        (and elixir? (= str-detect :auto))
+        (if (bin-str? bin (get-conf config :str-autodetect-len))
+          (str-or-bin bin)
+          bin)
+
+        :else bin))))
+
+(extend-type OtpErlangMap
+  IErlang
+  (-decode- [obj config]
+    (reduce (fn [acc ^java.util.Map$Entry x]
+              (assoc acc (-decode- (.getKey x) config) (-decode- (.getValue x) config)))
+            {}
+            (.entrySet obj))))
+
+(extend-type OtpErlangLong
+  IErlang
+  (-decode- [obj config]
+    (.longValue obj)))
+
+(extend-type OtpErlangDouble
+  IErlang
+  (-decode- [obj config]
+    (.doubleValue obj)))
+
+(extend-type Object
+  IErlang
+  (-decode- [obj config]
+    :decoding_error))

--- a/src/clojure_erlastic/encode.clj
+++ b/src/clojure_erlastic/encode.clj
@@ -1,0 +1,94 @@
+(ns clojure-erlastic.encode
+  (:require [clojure-erlastic.util :refer [get-conf printables utf-8 default-config]])
+  (:import (com.ericsson.otp.erlang OtpErlangAtom OtpErlangObject OtpErlangTuple
+                                    OtpErlangString OtpErlangList OtpErlangLong
+                                    OtpErlangBinary OtpErlangDouble OtpErlangMap)))
+
+(defn- erlang-objects
+  #^"[Lcom.ericsson.otp.erlang.OtpErlangObject;"
+    [xs]
+  (into-array OtpErlangObject xs))
+
+(defprotocol IErlang
+  (-encode- [this config]))
+
+(extend-type nil
+  IErlang
+  (-encode- [this config]
+    (if (= (get-conf config :convention) :elixir)
+      (OtpErlangAtom. "nil")
+      (OtpErlangAtom. "undefined"))))
+
+(extend-type Character
+  IErlang
+  (-encode- [this config]
+    (-encode- (int this) config)))
+
+(extend-type Long
+  IErlang
+  (-encode- [this config]
+    (OtpErlangLong. this)))
+
+(extend-type Integer
+  IErlang
+  (-encode- [this config]
+    (OtpErlangLong. (long this))))
+
+(extend-type clojure.lang.ISeq
+  IErlang
+  (-encode- [this config]
+    (OtpErlangList. (erlang-objects (map #(-encode- % config) this)))))
+
+(extend-type clojure.lang.Keyword
+  IErlang
+  (-encode- [this config]
+    (OtpErlangAtom. (name this))))
+
+(extend-type clojure.lang.IPersistentSet
+  IErlang
+  (-encode- [this config]
+    (OtpErlangList. (erlang-objects (map #(-encode- % config) this)))))
+
+(extend-type Float
+  IErlang
+  (-encode- [this config]
+    (OtpErlangDouble. (double this))))
+
+(extend-type Double
+  IErlang
+  (-encode- [this config]
+    (OtpErlangDouble. (double this))))
+
+(extend-type clojure.lang.IPersistentVector
+  IErlang
+  (-encode- [this config]
+    (OtpErlangTuple. (erlang-objects (map #(-encode- % config) this)))))
+
+(extend-type java.lang.String
+  IErlang
+  (-encode- [this config]
+    (if (= (get-conf config :convention) :elixir)
+      (OtpErlangBinary. (bytes (.getBytes ^String this "UTF-8")))
+      (-encode- (seq this) config))))
+
+(extend-type java.lang.Boolean
+  IErlang
+  (-encode- [this config]
+    (-encode- (keyword (str this)) this)))
+
+(extend-type clojure.lang.IPersistentMap
+  IErlang
+  (-encode- [this config]
+    (OtpErlangMap. (into-array OtpErlangObject (map #(-encode- % config) (keys this)))
+                   (into-array OtpErlangObject (map #(-encode- % config) (vals this))))))
+
+(extend-type (Class/forName "[B")
+  IErlang
+  (-encode- [this config]
+    (OtpErlangBinary. (bytes this))))
+
+(extend-type Object
+  IErlang
+  (-encode- [this config]
+    (-encode- (str this) config)))
+

--- a/src/clojure_erlastic/util.clj
+++ b/src/clojure_erlastic/util.clj
@@ -1,0 +1,23 @@
+(ns clojure-erlastic.util
+  (:import (java.nio.charset Charset)
+           (sun.nio.cs UTF_8)))
+
+;; CONFIGURATION
+(def default-config {:str-detect :none
+                     :convention :elixir
+                     :str-autodetect-len 10})
+
+(defn get-conf [config key]
+  (get config key (key default-config)))
+
+;; String conversion and detection utility functions
+(def ^UTF_8 utf-8 "The UTF-8 charset object" (Charset/forName "UTF-8"))
+
+(def printables #{Character/UPPERCASE_LETTER Character/TITLECASE_LETTER
+                  Character/SPACE_SEPARATOR
+                  Character/PARAGRAPH_SEPARATOR Character/LOWERCASE_LETTER
+                  Character/CURRENCY_SYMBOL Character/DECIMAL_DIGIT_NUMBER
+                  Character/DASH_PUNCTUATION Character/CONNECTOR_PUNCTUATION
+                  Character/END_PUNCTUATION Character/FINAL_QUOTE_PUNCTUATION
+                  Character/INITIAL_QUOTE_PUNCTUATION Character/START_PUNCTUATION
+                  Character/OTHER_PUNCTUATION})

--- a/test/clojure_erlastic/core_test.clj
+++ b/test/clojure_erlastic/core_test.clj
@@ -1,57 +1,58 @@
 (ns clojure-erlastic.core-test
-  (:require clojure-erlastic.core [clojure.test :refer :all]))
+  (:require [clojure-erlastic.core]
+            [clojure.test :refer :all]))
 
 (deftest encoding-test
-  (let [conf {:str-detect :none :convention :elixir :str-autodetect-len 10}
+  (let [conf   {:str-detect :none :convention :elixir :str-autodetect-len 10}
         encode (fn [obj] (clojure-erlastic.core/encode obj conf))
         decode (fn [obj] (clojure-erlastic.core/decode obj conf))]
-  (testing "Keyword encoding"
-    (is (= (-> :toto encode decode) :toto)))
-  (testing "Map encoding"
-    (is (= (-> {:a :b :c :d} encode decode) {:a :b :c :d})))
-  (testing "Vector encoding"
-    (is (= (-> [:a :b :c :d] encode decode) [:a :b :c :d])))
-  (testing "List encoding"
-    (is (= (-> '(:a :b :c :d) encode decode) '(:a :b :c :d))))
-  (testing "Set encoding : not bijective, set is list"
-    (is (= (-> #{:a :b :c :d} encode decode set) #{:a :b :c :d})))
-  (testing "Float encoding"
-    (is (= (-> 4.3 encode decode) 4.3)))
-  (testing "Bool encoding"
-    (is (= (-> true encode decode) true)))
-  (testing "Binary encoding"
-    (is (= (-> (byte-array (repeat 4 0)) encode decode seq) (seq (byte-array (repeat 4 0))))))
-  (testing "Nil encoding"
-    (is (= (-> nil encode decode) nil)))
-  (testing "Char encoding"
-    (is (= (-> \c encode decode char) \c)))
-  (testing "Elixir convention : string is binary"
-    (is (= (-> "toto" encode decode String.) "toto")))
-  (testing "Elixir convention : string codec not reflexive"
-    (is (not= (-> "toto" encode decode) "toto")))
-  (testing "Elixir convention : nil is :nil"
-    (is (= (-> nil encode .atomValue) "nil")))))
+    (testing "Keyword encoding"
+      (is (= (-> :toto encode decode) :toto)))
+    (testing "Map encoding"
+      (is (= (-> {:a :b :c :d} encode decode) {:a :b :c :d})))
+    (testing "Vector encoding"
+      (is (= (-> [:a :b :c :d] encode decode) [:a :b :c :d])))
+    (testing "List encoding"
+      (is (= (-> '(:a :b :c :d) encode decode) '(:a :b :c :d))))
+    (testing "Set encoding : not bijective, set is list"
+      (is (= (-> #{:a :b :c :d} encode decode set) #{:a :b :c :d})))
+    (testing "Float encoding"
+      (is (= (-> 4.3 encode decode) 4.3)))
+    (testing "Bool encoding"
+      (is (= (-> true encode decode) true)))
+    (testing "Binary encoding"
+      (is (= (-> (byte-array (repeat 4 0)) encode decode seq) (seq (byte-array (repeat 4 0))))))
+    (testing "Nil encoding"
+      (is (= (-> nil encode decode) nil)))
+    (testing "Char encoding"
+      (is (= (-> \c encode decode char) \c)))
+    (testing "Elixir convention : string is binary"
+      (is (= (-> "toto" encode decode String.) "toto")))
+    (testing "Elixir convention : string codec not reflexive"
+      (is (not= (-> "toto" encode decode) "toto")))
+    (testing "Elixir convention : nil is :nil"
+      (is (= (-> nil encode .atomValue) "nil")))))
 
 (deftest elixir-str-detect
-  (let [conf {:str-detect :auto :convention :elixir :str-autodetect-len 10}
+  (let [conf   {:str-detect :auto :convention :elixir :str-autodetect-len 10}
         encode (fn [obj] (clojure-erlastic.core/encode obj conf))
         decode (fn [obj] (clojure-erlastic.core/decode obj conf))]
-  (testing "Elixir : string is binary and reflexive codec"
-    (is (= (-> "€é;-[" encode decode) "€é;-[")))
-  (testing "Elixir : works if char split by detect len"
-    (is (= (-> "€€€€" encode decode) "€€€€")))
-  (testing "Elixir: no string when broken utf8"
-    (is (not= (type (decode (byte-array '(116 111 226 130)))) java.lang.String)))))
+    (testing "Elixir : string is binary and reflexive codec"
+      (is (= (-> "€é;-[" encode decode) "€é;-[")))
+    (testing "Elixir : works if char split by detect len"
+      (is (= (-> "€€€€" encode decode) "€€€€")))
+    (testing "Elixir: no string when broken utf8"
+      (is (not= (type (decode (byte-array '(116 111 226 130)))) java.lang.String)))))
 
 (deftest erlang-str-detect
-  (let [conf {:str-detect :auto :convention :erlang :str-autodetect-len 10}
+  (let [conf   {:str-detect :auto :convention :erlang :str-autodetect-len 10}
         encode (fn [obj] (clojure-erlastic.core/encode obj conf))
         decode (fn [obj] (clojure-erlastic.core/decode obj conf))]
-  (testing "erlang : string encode to list"
-    (is (= (-> "€é;-[" encode (.elements) first .longValue) 8364)))
-  (testing "erlang : string reflexive codec"
-    (is (= (-> "€é;-[" encode decode) "€é;-[")))
-  (testing "erlang : works if char split by detect len"
-    (is (= (-> "€€€€" encode decode) "€€€€")))
-  (testing "Elixir: no string when broken utf8"
-    (is (not= (type (decode (byte-array '(116 111 226 130)))) java.lang.String)))))
+    (testing "erlang : string encode to list"
+      (is (= (-> "€é;-[" encode (.elements) first .longValue) 8364)))
+    (testing "erlang : string reflexive codec"
+      (is (= (-> "€é;-[" encode decode) "€é;-[")))
+    (testing "erlang : works if char split by detect len"
+      (is (= (-> "€€€€" encode decode) "€€€€")))
+    (testing "Elixir: no string when broken utf8"
+      (is (not= (type (decode (byte-array '(116 111 226 130)))) java.lang.String)))))

--- a/test/clojure_erlastic/core_test.clj
+++ b/test/clojure_erlastic/core_test.clj
@@ -18,6 +18,10 @@
       (is (= (-> #{:a :b :c :d} encode decode set) #{:a :b :c :d})))
     (testing "Float encoding"
       (is (= (-> 4.3 encode decode) 4.3)))
+    (testing "Int encoding"
+      (is (= (-> 4 encode decode) 4)))
+    (testing "Long encoding"
+      (is (= (-> 12345678910 encode decode) 12345678910)))
     (testing "Bool encoding"
       (is (= (-> true encode decode) true)))
     (testing "Binary encoding"


### PR DESCRIPTION
With these changes, encode & decode is about 4 times faster. 

I testes this code using [criterium](https://github.com/hugoduncan/criterium).

```clojure
(use 'criterium.core)
(require '[clojure-erlastic.core :as c])

(def conf {:str-detect :none :convention :elixir :str-autodetect-len 10})

(def encode #(c/encode % conf))
(def decode #(c/decode % conf))

(defn f
  []
  (-> :toto encode decode)
  (-> {:a :b :c :d} encode decode)
  (-> [:a :b :c :d] encode decode)
  (-> '(:a :b :c :d) encode decode)
  (-> #{:a :b :c :d} encode decode)
  (-> 4.3 encode decode)
  (-> true encode decode)
  (-> (byte-array (repeat 4 0)) encode decode)
  (-> nil encode decode)
  (-> \c encode decode)
  (-> "toto" encode decode)
  nil)
(bench (f))
```

Before:

```
Evaluation count : 893640 in 60 samples of 14894 calls.
             Execution time mean : 72.383461 µs
    Execution time std-deviation : 5.949103 µs
   Execution time lower quantile : 65.927145 µs ( 2.5%)
   Execution time upper quantile : 83.833648 µs (97.5%)
                   Overhead used : 6.592387 ns
```

After:

```
Evaluation count : 3893340 in 60 samples of 64889 calls.
             Execution time mean : 15.769601 µs
    Execution time std-deviation : 394.241150 ns
   Execution time lower quantile : 15.214134 µs ( 2.5%)
   Execution time upper quantile : 16.606512 µs (97.5%)
                   Overhead used : 6.282802 ns
```